### PR TITLE
Usunięcie wsparcia dla web

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Według instrukcji na stronie https://reactnative.dev/docs/getting-started
 
 ## Klonowanie repozytorium i pierwsze uruchomienie
 1. Po sklonowaniu repozytorium trzeba użyć komendy `npm install` w głównym katalogu projektu.
-2. W terminalu użyć polecenia `npm install -g expo-cli`. Podgląd zmian w peojekcie podczas implementacji będzie realizowany przy użyciu aplikacji [Expo](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=pl) (zarówno na urządzeniu fizycznym jak i emulatorze).
+2. W terminalu użyć polecenia `npm install -g expo-cli`. Podgląd zmian w projekcie podczas implementacji będzie realizowany przy użyciu aplikacji [Expo](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=pl) (zarówno na urządzeniu fizycznym jak i emulatorze).
 3. Polecenie do uruchomienia projektu to `npm start` lub `expo start`. Rezultatem powinno być otwarcie karty "Metro builder" w przeglądarce internetowej oraz pokazanie się menu wyboru w terminalu.
  
 ## Problemy ogólne

--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,11 +1444,6 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -2155,24 +2150,10 @@
         "which": "^1.2.9"
       }
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "dayjs": {
       "version": "1.8.23",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.23.tgz",
       "integrity": "sha512-NmYHMFONftoZbeOhVz6jfiXI4zSiPN6NoVWJgC0aZQfYVwzy/ZpESPHuCcI0B8BUMpSJQ08zenHDbofOLKq8hQ=="
-    },
-    "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
     },
     "debug": {
       "version": "4.1.1",
@@ -2191,14 +2172,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "deep-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
-      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
     },
     "deepmerge": {
       "version": "3.3.0",
@@ -3455,11 +3428,6 @@
         "toidentifier": "1.0.0"
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3505,14 +3473,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "inline-style-prefixer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
-      "integrity": "sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "3.3.0",
@@ -3661,11 +3621,6 @@
           }
         }
       }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -4759,11 +4714,6 @@
       "resolved": "https://registry.npmjs.org/noop-fn/-/noop-fn-1.0.0.tgz",
       "integrity": "sha1-XzPUfxPSFQ35PgywNmmemC94/78="
     },
-    "normalize-css-color": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
-      "integrity": "sha1-Apkel8zOxmI/5XOvu/Deah8+n40="
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5304,17 +5254,6 @@
         }
       }
     },
-    "react-dom": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.15.0"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5617,54 +5556,10 @@
       "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz",
       "integrity": "sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q=="
     },
-    "react-native-web": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.11.7.tgz",
-      "integrity": "sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==",
-      "requires": {
-        "array-find-index": "^1.0.2",
-        "create-react-class": "^15.6.2",
-        "debounce": "^1.2.0",
-        "deep-assign": "^3.0.0",
-        "fbjs": "^1.0.0",
-        "hyphenate-style-name": "^1.0.2",
-        "inline-style-prefixer": "^5.0.3",
-        "normalize-css-color": "^1.0.2",
-        "prop-types": "^15.6.0",
-        "react-timer-mixin": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        },
-        "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
-      }
-    },
     "react-refresh": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",
       "integrity": "sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ=="
-    },
-    "react-timer-mixin": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
-      "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,12 @@
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web",
     "eject": "expo eject"
   },
   "dependencies": {
     "expo": "~37.0.3",
     "react": "~16.9.0",
-    "react-dom": "~16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",
-    "react-native-web": "~0.11.7"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz"
   },
   "devDependencies": {
     "babel-preset-expo": "~8.1.0",


### PR DESCRIPTION
Widzę, że wykorzystujemy tu expo, a nie RN CLI 😎 dlatego niewiele było do wywalenia, jedynie wsparcie dla web. W `package.json` zostawiłem skrypt `eject` - zamienia on wykorzystanie expo na RN CLI, dodając odpowiednie pliki. Gdy apka będzie gotowa, trzeba będzie właśnie zrobić eject, żeby móc zainstalować aplikację na telefonie jako samodzielną aplikację. A samo expo pewnie wykorzystamy również w taskach