### PR TITLE
Przycisk grup, wymagane pola

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -5,6 +5,8 @@ import { icons, formLabels, modes, contactLabels } from '../StringsHelper';
 import { MaterialCommunityIcons } from 'react-native-vector-icons';
 import RNPickerSelect from 'react-native-picker-select';
 import { contactT, emailsT, navigationT, numbersT, snackbarT } from '../CustomTypes';
+import GroupButton from './GroupButton';
+import { Group } from '../../redux/reducers/GroupsReducer';
 
 const styles = StyleSheet.create({
     container: {
@@ -55,6 +57,7 @@ interface Props {
     emails: emailsT;
     navigation: navigationT;
     contact: contactT;
+    groups: Group[];
     image: string;
     isMenuVisible: boolean;
     pickImage: () => void;
@@ -82,6 +85,7 @@ const AddEdit = (props: Props): JSX.Element => {
         emails,
         navigation,
         contact,
+        groups,
         image,
         isMenuVisible,
         pickImage,
@@ -220,8 +224,6 @@ const AddEdit = (props: Props): JSX.Element => {
             </Snackbar>
         );
 
-    const groupsButton = (): JSX.Element => <Button title={'Grupy'} onPress={(): void => onGroups(4)} />;
-
     return (
         <View style={styles.container}>
             <ScrollView>
@@ -266,7 +268,7 @@ const AddEdit = (props: Props): JSX.Element => {
                     {mapEmails(emails)}
                     {plusButton(formLabels.email)}
 
-                    {groupsButton()}
+                    <GroupButton onGroups={onGroups} groups={groups} />
                 </View>
             </ScrollView>
             {showSnackbar()}

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Button, Dimensions, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+    Dimensions,
+    ScrollView,
+    StyleSheet,
+    TouchableOpacity,
+    View,
+} from 'react-native';
 import { TextInput, Avatar, IconButton, Snackbar, Menu, Divider } from 'react-native-paper';
 import { icons, formLabels, modes, contactLabels } from '../StringsHelper';
 import { MaterialCommunityIcons } from 'react-native-vector-icons';
@@ -142,6 +148,7 @@ const AddEdit = (props: Props): JSX.Element => {
         icon: string,
         label: string,
         listLength: number,
+        isNumeric: boolean,
     ): JSX.Element => (
         <View key={index}>
             <View style={styles.row}>
@@ -151,6 +158,7 @@ const AddEdit = (props: Props): JSX.Element => {
                     value={phoneOrEmail}
                     style={styles.inputText}
                     onChangeText={(text): void => onChangeTextInput(label, text, index)}
+                    keyboardType={isNumeric ? 'numeric' : 'email-address'}
                 />
                 <View style={styles.iconContainer}>
                     {listLength > 1 && (
@@ -184,6 +192,7 @@ const AddEdit = (props: Props): JSX.Element => {
                 icons.phone,
                 formLabels.number,
                 value.length,
+                true,
             );
         });
 
@@ -196,6 +205,7 @@ const AddEdit = (props: Props): JSX.Element => {
                 icons.email,
                 formLabels.email,
                 value.length,
+                false,
             );
         });
 

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -64,7 +64,7 @@ interface Props {
     setImage: (string) => void;
     setIsMenuVisible: (boolean) => void;
     snackbar: snackbarT;
-    onGroups: (id: number) => void;
+    onGroups: (id: number | null) => void;
     onChangeName: (name: string) => void;
     onChangeSecondName: (secondName: string) => void;
     onChangeLastName: (lastName: string) => void;
@@ -268,7 +268,7 @@ const AddEdit = (props: Props): JSX.Element => {
                     {mapEmails(emails)}
                     {plusButton(formLabels.email)}
 
-                    <GroupButton onGroups={onGroups} groups={groups} />
+                    <GroupButton onGroups={onGroups} groups={groups} id={contact.id} />
                 </View>
             </ScrollView>
             {showSnackbar()}

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -7,34 +7,21 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         alignSelf: 'center',
-    },
-    touchableOpacity: {
-        backgroundColor: 'blue',
-        width: '80%',
-        paddingVertical: 15,
-        paddingHorizontal: 10,
+        backgroundColor: '#dcedc8',
         marginBottom: 10,
     },
-    arrowContainer: {
-        backgroundColor: 'red',
-        padding: 0,
-        margin: 0,
+    touchableOpacity: {
+        paddingVertical: 15,
+        paddingHorizontal: 10,
     },
     row: {
         flexDirection: 'row',
         justifyContent: 'space-between',
     },
-    textContainer: {
-        width: '80%',
-        justifyContent: 'center',
-    },
     text: {
+        width: '80%',
         alignSelf: 'center',
-        backgroundColor: 'yellow',
-    },
-    icon: {
-        alignSelf: 'flex-end',
-        backgroundColor: 'green',
+        fontSize: 15,
     },
 });
 
@@ -46,22 +33,25 @@ interface Props {
 const GroupButton = (props: Props): JSX.Element => {
     const { onGroups, groups } = props;
     let groupString = '';
-    groups.map((row, index) => {
-        if (index === groups.length - 1) {
-            groupString += row.name;
-        } else {
-            groupString += row.name + ', ';
-        }
-    });
+    if(groups.length === 0) {
+        groupString = 'Click to add contact to groups!';
+    } else {
+        groups.map((row, index) => {
+            if (index === groups.length - 1) {
+                groupString += row.name;
+            } else {
+                groupString += row.name + ', ';
+            }
+        });
+    }
+
 
     return (
         <View style={styles.container}>
             <TouchableOpacity onPress={(): void => onGroups(4)} style={styles.touchableOpacity}>
                 <View style={styles.row}>
-                    <View style={styles.textContainer}>
-                        <Text style={styles.text}>{groupString}</Text>
-                    </View>
-                    <MaterialCommunityIcons size={50} name={'greater-than'} style={styles.icon} />
+                    <Text style={styles.text}>{groupString}</Text>
+                    <MaterialCommunityIcons size={50} name={'greater-than'} />
                 </View>
             </TouchableOpacity>
         </View>

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -19,6 +19,7 @@ const styles = StyleSheet.create({
         height: '100%',
         paddingTop: 10,
         paddingBottom: 10,
+        paddingRight: 10,
     },
     text: {
         width: '80%',
@@ -54,7 +55,7 @@ const GroupButton = (props: Props): JSX.Element => {
             <TouchableOpacity onPress={(): void => onGroups(id)}>
                 <View style={styles.row}>
                     <Text style={styles.text}>{groupString}</Text>
-                    <MaterialCommunityIcons size={50} name={'greater-than'} />
+                    <MaterialCommunityIcons size={30} name={'greater-than'} />
                 </View>
             </TouchableOpacity>
         </View>

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -7,33 +7,37 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         alignSelf: 'center',
+        justifyContent: 'center',
         backgroundColor: '#dcedc8',
         marginBottom: 10,
-    },
-    touchableOpacity: {
-        paddingVertical: 15,
-        paddingHorizontal: 10,
+        borderRadius: 20,
     },
     row: {
         flexDirection: 'row',
+        alignItems: 'center',
         justifyContent: 'space-between',
+        height: '100%',
+        paddingTop: 10,
+        paddingBottom: 10,
     },
     text: {
         width: '80%',
         alignSelf: 'center',
         fontSize: 15,
+        paddingLeft: 15,
     },
 });
 
 interface Props {
-    onGroups: (id: number) => void;
+    onGroups: (id: number | null) => void;
     groups: Group[];
+    id: number | null;
 }
 
 const GroupButton = (props: Props): JSX.Element => {
-    const { onGroups, groups } = props;
+    const { onGroups, groups, id } = props;
     let groupString = '';
-    if(groups.length === 0) {
+    if (groups.length === 0) {
         groupString = 'Click to add contact to groups!';
     } else {
         groups.map((row, index) => {
@@ -45,10 +49,9 @@ const GroupButton = (props: Props): JSX.Element => {
         });
     }
 
-
     return (
         <View style={styles.container}>
-            <TouchableOpacity onPress={(): void => onGroups(4)} style={styles.touchableOpacity}>
+            <TouchableOpacity onPress={(): void => onGroups(id)}>
                 <View style={styles.row}>
                     <Text style={styles.text}>{groupString}</Text>
                     <MaterialCommunityIcons size={50} name={'greater-than'} />

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Text, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Group } from '../../redux/reducers/GroupsReducer';
+import { MaterialCommunityIcons } from 'react-native-vector-icons';
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignSelf: 'center',
+    },
+    touchableOpacity: {
+        backgroundColor: 'blue',
+        width: '80%',
+        paddingVertical: 15,
+        paddingHorizontal: 10,
+        marginBottom: 10,
+    },
+    arrowContainer: {
+        backgroundColor: 'red',
+        padding: 0,
+        margin: 0,
+    },
+    row: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+    },
+    textContainer: {
+        width: '80%',
+        justifyContent: 'center',
+    },
+    text: {
+        alignSelf: 'center',
+        backgroundColor: 'yellow',
+    },
+    icon: {
+        alignSelf: 'flex-end',
+        backgroundColor: 'green',
+    },
+});
+
+interface Props {
+    onGroups: (id: number) => void;
+    groups: Group[];
+}
+
+const GroupButton = (props: Props): JSX.Element => {
+    const { onGroups, groups } = props;
+    let groupString = '';
+    groups.map((row, index) => {
+        if (index === groups.length - 1) {
+            groupString += row.name;
+        } else {
+            groupString += row.name + ', ';
+        }
+    });
+
+    return (
+        <View style={styles.container}>
+            <TouchableOpacity onPress={(): void => onGroups(4)} style={styles.touchableOpacity}>
+                <View style={styles.row}>
+                    <View style={styles.textContainer}>
+                        <Text style={styles.text}>{groupString}</Text>
+                    </View>
+                    <MaterialCommunityIcons size={50} name={'greater-than'} style={styles.icon} />
+                </View>
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+export default GroupButton;

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable prettier/prettier */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import AddEdit from './AddEdit';
 import { getContacts, getGroups } from '../../redux/selectors/Selectors';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import * as ImagePicker from 'expo-image-picker';
-import { contactLabels, defaultCathegory, formLabels, modes } from '../StringsHelper';
-import { createContact, updateContact } from '../../redux/actions/ActionCreators';
-import { contactT } from '../CustomTypes';
+import { defaultCathegory, formLabels, modes } from '../StringsHelper';
+import { contactT, emailsT, numbersT, validationT } from '../CustomTypes';
 import { Alert } from 'react-native';
 import { Group } from '../../redux/reducers/GroupsReducer';
+import { createContact, updateContact } from '../../redux/actions/ActionCreators';
 
 const showDeclinedPermissionAlert = (): void => {
     Alert.alert(
@@ -35,14 +35,26 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const [firstName, setFirstName] = useState(isEdit ? contacts[id].firstName : '');
     const [secondName, setSecondName] = useState(isEdit ? contacts[id].secondName : '');
     const [lastName, setSurname] = useState(isEdit ? contacts[id].lastName : '');
-    const [numbers, setNumbers] = useState(isEdit ? (contacts[id].telNumbers) : ([{ number: '', category: defaultCathegory}]));
+    const [numbers, setNumbers] = useState(isEdit ? (contacts[id].telNumbers) : ([{
+        number: '',
+        category: defaultCathegory
+    }]));
     const [deletedNumber, setDeletedNumber] = useState({ index: -1, delNumber: { number: '', category: '' } });
-    const [emails, setEmails] = useState(isEdit ? (contacts[id].emails) : ([{ email: '', category: defaultCathegory }]));
+    const [emails, setEmails] = useState(isEdit ? (contacts[id].emails) : ([{
+        email: '',
+        category: defaultCathegory
+    }]));
     const [deletedEmail, setDeletedEmail] = useState({ index: -1, delEmail: { email: '', category: '' } });
     const [snackbar, setSnackbar] = useState({ isVisible: false, message: '', isActionVisible: false, label: '' });
     const [isDeleteClicked, setIsDeleteClicked] = useState(false); //Logika pomagająca przy procesie usuwania/cofania usunięcia,
+    const [dataValid, setDataValid] = useState({
+        nameOrOneNumberEmpty: true,
+        oneOfNumbersEmpty: true,
+        oneOfEmailsEmpty: true
+    });
 
-    const filterGroupsForContact = ():Group[] => {
+
+    const filterGroupsForContact = (): Group[] => {
         return groups.filter((row) => {
             return row.contactsIds.indexOf(id) >= 0;
         })
@@ -81,12 +93,46 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         setSnackbar({ isVisible: true, message: message, isActionVisible: isActionVisible, label: label });
     };
 
+    const checkDataValidation = (): validationT => {
+        //Sprawdza czy jest imie i co najmniej jeden numer telefonu
+        const nameAndOneNumberEmpty: boolean = !(!firstName || firstName.length === 0) && !(!numbers[0].number || numbers[0].number.length === 0) && !(!numbers[0].category || numbers[0].category.length === 0);
+        //Sprawdza czy wszystkie dodane pola tekstowe dla numerów telefonów i adresów email mają wartości
+        const tmpNumbers: numbersT = [...numbers];
+        let numbersEmpty = true;
+        const tmpEmails: emailsT = [...emails];
+        let emailsEmpty = true;
+        tmpNumbers.forEach((row) => {
+            if (!(!row.number || row.number.length === 0) && !(!row.category || row.category.length === 0)) {
+                numbersEmpty = false;
+            } else {
+                numbersEmpty = true;
+            }
+        });
+
+        if (tmpEmails.length > 1) {
+            tmpEmails.forEach((row) => {
+                if (!(!row.email || row.email.length === 0) && !(!row.category || row.category.length === 0)) {
+                    emailsEmpty = false;
+                } else {
+                    emailsEmpty = true;
+                }
+            });
+        } else {
+            emailsEmpty = false;
+        }
+        return {nameOrOneNumberEmpty: !nameAndOneNumberEmpty, oneOfNumbersEmpty: numbersEmpty, oneOfEmailsEmpty: emailsEmpty};
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    //Nie mogę przekazać w deeps nazwy metody, bo robi się nieskończona pętla
+    useEffect(() => setDataValid(checkDataValidation()), [firstName, emails, numbers]);
+
     //metody
     const addInputField = (label: string): void => {
         if (label === formLabels.number) {
             setNumbers([...numbers, { number: '', category: defaultCathegory }]);
         } else if (label === formLabels.email) {
-            setEmails([...emails, { email: '' , category: defaultCathegory }]);
+            setEmails([...emails, { email: '', category: defaultCathegory }]);
         } else {
             onShowSnackbar(true, 'Something went wrong.', false, '');
             console.log('Błąd podczas dodawania nowego pola, nieznana etykieta.');
@@ -131,7 +177,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
                 console.log('Błąd podczas zmiany danych w rozwijanym menu, nieznana etykieta.');
             }
         }
-        setIsDeleteClicked(false);
+        setIsDeleteClicked(false)
     };
 
     const onDeleteTextInput = (label: string, index: number): void => {
@@ -171,14 +217,28 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         }
     };
 
-    const onSaveContact = (): void => {
-        // TODO: walidacja danych
-        if (mode === modes.create) {
-            dispatch(createContact(buildContactObject()));
-        } else if (mode === modes.edit && id !== null) {
-            dispatch(updateContact(buildContactObject(), id));
+    const saveMessage = (dataValidOk: boolean): void => {
+        if (dataValidOk) {
+            onShowSnackbar(true, 'Contact saved.', false, '');
+        } else if (dataValid.nameOrOneNumberEmpty) {
+            onShowSnackbar(true, 'Please enter your name and at least one phone number', false, '');
+        } else if (dataValid.oneOfNumbersEmpty) {
+            onShowSnackbar(true, 'Fill out the fields with the phone number', false, '');
+        } else if (dataValid.oneOfEmailsEmpty) {
+            onShowSnackbar(true, 'Fill out the fields with the email adress', false, '');
         }
-        onShowSnackbar(true, 'Contact saved.', false, '');
+    };
+
+    const onSaveContact = (): void => {
+        const dataValidOk = !dataValid.nameOrOneNumberEmpty && !dataValid.oneOfNumbersEmpty && !dataValid.oneOfEmailsEmpty;
+        if (dataValidOk) {
+            if (mode === modes.create) {
+                dispatch(createContact(buildContactObject()));
+            } else if (mode === modes.edit && id !== null) {
+                dispatch(updateContact(buildContactObject(), id));
+            }
+        }
+        saveMessage(dataValidOk);
     };
 
     const checkCameraPermissions = useCallback(async (): Promise<boolean> => {

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -123,8 +123,8 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         return {nameOrOneNumberEmpty: !nameAndOneNumberEmpty, oneOfNumbersEmpty: numbersEmpty, oneOfEmailsEmpty: emailsEmpty};
     };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     //Nie mogę przekazać w deeps nazwy metody, bo robi się nieskończona pętla
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => setDataValid(checkDataValidation()), [firstName, emails, numbers]);
 
     //metody

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -230,6 +230,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     };
 
     const onSaveContact = (): void => {
+        //Walidacja odbywa się przy pomocy metody checkDataValidation
         const dataValidOk = !dataValid.nameOrOneNumberEmpty && !dataValid.oneOfNumbersEmpty && !dataValid.oneOfEmailsEmpty;
         if (dataValidOk) {
             if (mode === modes.create) {

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -5,7 +5,7 @@ import { getContacts, getGroups } from '../../redux/selectors/Selectors';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import * as ImagePicker from 'expo-image-picker';
-import { formLabels, modes } from '../StringsHelper';
+import { contactLabels, defaultCathegory, formLabels, modes } from '../StringsHelper';
 import { createContact, updateContact } from '../../redux/actions/ActionCreators';
 import { contactT } from '../CustomTypes';
 import { Alert } from 'react-native';
@@ -35,9 +35,9 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const [firstName, setFirstName] = useState(isEdit ? contacts[id].firstName : '');
     const [secondName, setSecondName] = useState(isEdit ? contacts[id].secondName : '');
     const [lastName, setSurname] = useState(isEdit ? contacts[id].lastName : '');
-    const [numbers, setNumbers] = useState(isEdit ? (contacts[id].telNumbers) : ([{ number: '', category: '' }]));
+    const [numbers, setNumbers] = useState(isEdit ? (contacts[id].telNumbers) : ([{ number: '', category: defaultCathegory}]));
     const [deletedNumber, setDeletedNumber] = useState({ index: -1, delNumber: { number: '', category: '' } });
-    const [emails, setEmails] = useState(isEdit ? (contacts[id].emails) : ([{ email: '', category: '' }]));
+    const [emails, setEmails] = useState(isEdit ? (contacts[id].emails) : ([{ email: '', category: defaultCathegory }]));
     const [deletedEmail, setDeletedEmail] = useState({ index: -1, delEmail: { email: '', category: '' } });
     const [snackbar, setSnackbar] = useState({ isVisible: false, message: '', isActionVisible: false, label: '' });
     const [isDeleteClicked, setIsDeleteClicked] = useState(false); //Logika pomagająca przy procesie usuwania/cofania usunięcia,
@@ -84,9 +84,9 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     //metody
     const addInputField = (label: string): void => {
         if (label === formLabels.number) {
-            setNumbers([...numbers, { category: '', number: '' }]);
+            setNumbers([...numbers, { number: '', category: defaultCathegory }]);
         } else if (label === formLabels.email) {
-            setEmails([...emails, { category: '', email: '' }]);
+            setEmails([...emails, { email: '' , category: defaultCathegory }]);
         } else {
             onShowSnackbar(true, 'Something went wrong.', false, '');
             console.log('Błąd podczas dodawania nowego pola, nieznana etykieta.');

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable prettier/prettier */
 import React, { useCallback, useState } from 'react';
 import AddEdit from './AddEdit';
-import { getContacts } from '../../redux/selectors/Selectors';
+import { getContacts, getGroups } from '../../redux/selectors/Selectors';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import * as ImagePicker from 'expo-image-picker';
@@ -9,6 +9,7 @@ import { formLabels, modes } from '../StringsHelper';
 import { createContact, updateContact } from '../../redux/actions/ActionCreators';
 import { contactT } from '../CustomTypes';
 import { Alert } from 'react-native';
+import { Group } from '../../redux/reducers/GroupsReducer';
 
 const showDeclinedPermissionAlert = (): void => {
     Alert.alert(
@@ -26,6 +27,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const { navigate } = useNavigation();
     const { id, mode } = route.params;
     const contacts = useSelector(getContacts);
+    const groups = useSelector(getGroups);
     const dispatch = useDispatch();
     const isEdit = mode === modes.edit;
     const [isMenuVisible, setIsMenuVisible] = useState(false);
@@ -39,6 +41,15 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const [deletedEmail, setDeletedEmail] = useState({ index: -1, delEmail: { email: '', category: '' } });
     const [snackbar, setSnackbar] = useState({ isVisible: false, message: '', isActionVisible: false, label: '' });
     const [isDeleteClicked, setIsDeleteClicked] = useState(false); //Logika pomagająca przy procesie usuwania/cofania usunięcia,
+
+    const filterGroupsForContact = ():Group[] => {
+        return groups.filter((row) => {
+            return row.contactsIds.indexOf(id) >= 0;
+        })
+    };
+
+    const filteredGroups = filterGroupsForContact();
+
     const buildContactObject = (): contactT => {
         return {
             id: null,
@@ -70,7 +81,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         setSnackbar({ isVisible: true, message: message, isActionVisible: isActionVisible, label: label });
     };
 
-    // metody
+    //metody
     const addInputField = (label: string): void => {
         if (label === formLabels.number) {
             setNumbers([...numbers, { category: '', number: '' }]);
@@ -162,7 +173,6 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
 
     const onSaveContact = (): void => {
         // TODO: walidacja danych
-        // TODO: wyświetlanie grup należących do kontaktu
         if (mode === modes.create) {
             dispatch(createContact(buildContactObject()));
         } else if (mode === modes.edit && id !== null) {
@@ -249,6 +259,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             emails={emails}
             navigation={navigation}
             contact={contact}
+            groups={filteredGroups}
             image={image}
             isMenuVisible={isMenuVisible}
             pickImage={pickImage}

--- a/src/screens/CustomTypes.ts
+++ b/src/screens/CustomTypes.ts
@@ -33,3 +33,9 @@ export type snackbarT = {
 export type navigationT = {
     setOptions(param: { headerRight: () => JSX.Element; title: string }): void;
 };
+
+export type validationT = {
+    nameOrOneNumberEmpty: boolean;
+    oneOfNumbersEmpty: boolean;
+    oneOfEmailsEmpty: boolean;
+};

--- a/src/screens/StringsHelper.ts
+++ b/src/screens/StringsHelper.ts
@@ -9,8 +9,10 @@ export const contactLabels = [
     { label: 'Work', value: 'work' },
     { label: 'Fax', value: 'fax' },
     { label: 'Pager', value: 'pager' },
-    { label: 'Other', value: 'other' },
+    { label: 'Other', value: 'other' }, //Zostawić zawsze na końcu
 ];
+
+export const defaultCathegory = contactLabels[contactLabels.length - 1].value;
 
 export const formLabels = {
     name: 'Name',


### PR DESCRIPTION
#27 
Walidacje polega na tym, że: 

- trzeba mieć podane imię i jeden numer telefonu. 
- Każdy kolejny dodany numer telefonu musi mieć wpisany numer i kategorię 
- Dodanie email nie jest obowiązkowe, chyba, że ktoś doda kolejne pole tekstowe dla emaila (tzn. jedno pole domyślne tworzone przy wchodzeniu do formularza nie jest wymagane, jeśli dodamy kolejne to są wymagane wszystkie)

//Edit: nie działa odświeżanie się listy grup na przycisku, tzn.
wejście w dodaj -> wejście w grupy -> przypisanie grupy do kontaktu -> powrót (tutaj na liście są grupy, to jest w porządku ) -> powrót do listy kontaktów -> wejście w dodaj (tutaj pozostają przypisane grupy, tak nie powinno być)
Po stronie add/edit raczej nie będę w stanie tego rozwiązać