### PR TITLE
Przycisk grup

### DIFF
--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -78,7 +78,7 @@ interface Props {
     onDismissSnackbar: () => void;
     onUndoPressed: (label: string) => void;
     useCamera: () => void;
-    userGroups: number[];
+    userGroups: Group[];
 }
 
 const AddEdit = (props: Props): JSX.Element => {

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Dimensions, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { TextInput, IconButton, Snackbar, Menu, Divider } from 'react-native-paper';
 import { icons, formLabels, modes, contactLabels } from '../StringsHelper';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
 import { MaterialCommunityIcons } from 'react-native-vector-icons';
 import RNPickerSelect from 'react-native-picker-select';
 import { navigationT, snackbarT } from '../CustomTypes';
@@ -78,7 +80,6 @@ interface Props {
     onDismissSnackbar: () => void;
     onUndoPressed: (label: string) => void;
     useCamera: () => void;
-    userGroups: Group[];
 }
 
 const AddEdit = (props: Props): JSX.Element => {
@@ -106,7 +107,6 @@ const AddEdit = (props: Props): JSX.Element => {
         onDismissSnackbar,
         onUndoPressed,
         useCamera,
-        userGroups,
     } = props;
 
     React.useLayoutEffect(() => {
@@ -276,7 +276,7 @@ const AddEdit = (props: Props): JSX.Element => {
                     {mapEmails(emails)}
                     {plusButton(formLabels.email)}
 
-                    <GroupButton onGroups={onGroups} groups={groups} userGroups={userGroups} id={contact.id} />
+                    <GroupButton onGroups={onGroups} groups={groups} id={contact.id} />
                 </View>
             </ScrollView>
             {showSnackbar()}

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -32,12 +32,13 @@ const styles = StyleSheet.create({
 interface Props {
     onGroups: (id: number | null) => void;
     groups: Group[];
-    userGroups: number[];
+    userGroups: Group[];
     id: number | null;
 }
 
 const GroupButton = (props: Props): JSX.Element => {
-    const { onGroups, groups, id } = props;
+    const { onGroups, groups, userGroups, id } = props;
+    console.log(userGroups);
     let groupString = '';
     if (groups.length === 0) {
         groupString = 'Click to add contact to groups!';

--- a/src/screens/AddEdit/GroupButton.tsx
+++ b/src/screens/AddEdit/GroupButton.tsx
@@ -32,13 +32,12 @@ const styles = StyleSheet.create({
 interface Props {
     onGroups: (id: number | null) => void;
     groups: Group[];
-    userGroups: Group[];
     id: number | null;
 }
 
 const GroupButton = (props: Props): JSX.Element => {
-    const { onGroups, groups, userGroups, id } = props;
-    console.log(userGroups);
+    const { onGroups, groups, id} = props;
+
     let groupString = '';
     if (groups.length === 0) {
         groupString = 'Click to add contact to groups!';

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -9,7 +9,7 @@ import { defaultCathegory, formLabels, modes } from '../StringsHelper';
 import { validationT } from '../CustomTypes';
 import { Alert } from 'react-native';
 import { Group } from '../../redux/reducers/GroupsReducer';
-import { createContact, updateContact } from '../../redux/actions/ActionCreators';
+import { createContact, removeTempGroups, updateContact } from '../../redux/actions/ActionCreators';
 import { Contact, ContactEmail, ContactNumber } from '../../redux/reducers/ContactsReducer';
 import addNewestContactToGroup from '../../redux/actions/addNewestContactToGroups';
 
@@ -148,6 +148,11 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     //Nie mogę przekazać w deeps nazwy metody, bo robi się nieskończona pętla
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => setDataValid(checkDataValidation()), [firstName, emails, numbers]);
+    //Czyszczenie grup za każdym razem przy wejściu w dodawanie kontaktu
+    useEffect(() => {
+        dispatch(removeTempGroups());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     //metody
     const addInputField = (label: string): void => {
@@ -366,7 +371,6 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             onDismissSnackbar={onDismissSnackbar}
             onUndoPressed={onUndoPressed}
             useCamera={useCamera}
-            userGroups={filteredGroups}
         />
     );
 };

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -69,9 +69,15 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
 
 
     const filterGroupsForContact = (): Group[] => {
-        return groups.filter((row) => {
-            return row.contactsIds.indexOf(id) >= 0;
-        })
+        if(isEdit) {
+            return groups.filter((row) => {
+                return row.contactsIds.indexOf(id) >= 0;
+            })
+        } else {
+            return groups.filter((row) => {
+                return tempGroupsIds.indexOf(row.id) >= 0;
+            })
+        }
     };
 
     const filteredGroups = filterGroupsForContact();
@@ -360,7 +366,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             onDismissSnackbar={onDismissSnackbar}
             onUndoPressed={onUndoPressed}
             useCamera={useCamera}
-            userGroups={tempGroupsIds}
+            userGroups={filteredGroups}
         />
     );
 };


### PR DESCRIPTION
Closes #50 

Grupy powinny poprawnie wyświetlać się na przycisku podczas edycji i tworzenia nowego kontaktu, również w scenariuszu:
FAB -> przycisk grup -> dodanie grup -> powrót do dodawania kontaktu -> powrót do listy bez zapisu -> FAB