### PR TITLE
Modyfikacja snackbarów i zachowania zapisu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,7 @@ import configureStore from './src/redux/Store';
 import GroupsListScreen from './src/screens/GroupsList';
 import { colors } from './src/styles/common';
 import { StatusBar } from 'react-native';
-import { SnackbarProvider } from './src/screens/ToastContent';
+import { SnackbarProvider } from './src/screens/SnackbarContent';
 import SnackbarCustom from './src/screens/SnackbarCustom';
 
 const Stack = createStackNavigator();

--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,8 @@ import configureStore from './src/redux/Store';
 import GroupsListScreen from './src/screens/GroupsList';
 import { colors } from './src/styles/common';
 import { StatusBar } from 'react-native';
+import { SnackbarProvider } from './src/screens/ToastContent';
+import SnackbarCustom from './src/screens/SnackbarCustom';
 
 const Stack = createStackNavigator();
 const store = configureStore();
@@ -22,58 +24,62 @@ const persistedStore = persistStore(store);
 const App = (): ReactElement => {
     return (
         <Provider store={store}>
-            <PersistGate persistor={persistedStore} loading={null}>
-                <PaperProvider>
-                <StatusBar backgroundColor={colors.primaryDark} />
-                <NavigationContainer>
-                    <Stack.Navigator
-                        initialRouteName='List'
-                        screenOptions={{
-                            cardStyle: {
-                                //Styl całego widoku
-                                backgroundColor: colors.background,
-                            },
-                            headerStyle: {
-                                backgroundColor: colors.primaryDark,
-                            },
-                            headerTintColor: colors.tint,
-                        }}
-                    >
-                        <Stack.Screen
-                            name='List'
-                            component={ContactsListScreen}
-                            options={{ headerShown: false }}
-                        />
-                        <Stack.Screen
-                            name='Details'
-                            component={DetailsScreen}
-                            options={{ title: 'Details' }}
-                        />
-                        <Stack.Screen
-                            name='AddEdit'
-                            component={AddEditScreen}
-                            options={{ title: 'New contact/Edit Contact' }}
-                        />
-                        <Stack.Screen
-                            name='Groups'
-                            component={GroupsScreen}
-                            options={{ title: 'Select groups' }}
-                        />
-                        <Stack.Screen
-                            name='GroupsList'
-                            component={GroupsListScreen}
-                            options={{ title: 'My groups' }}
-                        />
-                        <Stack.Screen
-                            name='ContactsListForGroup'
-                            component={ContactsListScreen}
-                            options={{ title: 'Contacts in group' }}
-                        />
-                    </Stack.Navigator>
-                </NavigationContainer>
-                </PaperProvider>
-            </PersistGate>
+            <SnackbarProvider>
+                <PersistGate persistor={persistedStore} loading={null}>
+                    <PaperProvider>
+                        <StatusBar backgroundColor={colors.primaryDark} />
+                        <NavigationContainer>
+                            <Stack.Navigator
+                                initialRouteName='List'
+                                screenOptions={{
+                                    cardStyle: {
+                                        //Styl całego widoku
+                                        backgroundColor: colors.background,
+                                    },
+                                    headerStyle: {
+                                        backgroundColor: colors.primaryDark,
+                                    },
+                                    headerTintColor: colors.tint,
+                                }}
+                            >
+                                <Stack.Screen
+                                    name='List'
+                                    component={ContactsListScreen}
+                                    options={{ headerShown: false }}
+                                />
+                                <Stack.Screen
+                                    name='Details'
+                                    component={DetailsScreen}
+                                    options={{ title: 'Details' }}
+                                />
+                                <Stack.Screen
+                                    name='AddEdit'
+                                    component={AddEditScreen}
+                                    options={{ title: 'New contact/Edit Contact' }}
+                                />
+                                <Stack.Screen
+                                    name='Groups'
+                                    component={GroupsScreen}
+                                    options={{ title: 'Select groups' }}
+                                />
+                                <Stack.Screen
+                                    name='GroupsList'
+                                    component={GroupsListScreen}
+                                    options={{ title: 'My groups' }}
+                                />
+                                <Stack.Screen
+                                    name='ContactsListForGroup'
+                                    component={ContactsListScreen}
+                                    options={{ title: 'Contacts in group' }}
+                                />
+                            </Stack.Navigator>
+                        </NavigationContainer>
+                    </PaperProvider>
+                </PersistGate>
+                <SnackbarCustom />
+            </SnackbarProvider>
         </Provider>
+
     );
 };
 

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import { TextInput, IconButton, Snackbar, Menu, Divider } from 'react-native-paper';
+import { TextInput, IconButton, Menu, Divider } from 'react-native-paper';
 import { icons, formLabels, modes, contactLabels } from '../StringsHelper';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { MaterialCommunityIcons } from 'react-native-vector-icons';
 import RNPickerSelect from 'react-native-picker-select';
-import { navigationT, snackbarT } from '../CustomTypes';
+import { navigationT } from '../CustomTypes';
 import GroupButton from './GroupButton';
 import { Group } from '../../redux/reducers/GroupsReducer';
 import ProperAvatar from '../ProperAvatar';
@@ -46,11 +46,6 @@ const styles = StyleSheet.create({
         paddingLeft: padding.sm,
         color: colors.icon,
     },
-    snackbar: {
-        position: 'absolute',
-        backgroundColor: colors.primaryDark,
-        bottom: 0,
-    },
     dropdown: {
         width: '45%',
     },
@@ -68,7 +63,6 @@ interface Props {
     pickImage: () => void;
     setImage: (string) => void;
     setIsMenuVisible: (boolean) => void;
-    snackbar: snackbarT;
     onGroups: (id: number | null) => void;
     onChangeName: (name: string) => void;
     onChangeSecondName: (secondName: string) => void;
@@ -78,7 +72,6 @@ interface Props {
     onDeleteTextInput: (label: string, index: number) => void;
     addInputField: (label: string) => void;
     onChangeDropdown: (label: string, test: string, index: number) => void;
-    onDismissSnackbar: () => void;
     onUndoPressed: (label: string) => void;
     useCamera: () => void;
     isSubmiting: boolean;
@@ -96,7 +89,6 @@ const AddEdit = (props: Props): JSX.Element => {
         isMenuVisible,
         pickImage,
         setIsMenuVisible,
-        snackbar,
         onGroups,
         onChangeName,
         onChangeSecondName,
@@ -106,8 +98,6 @@ const AddEdit = (props: Props): JSX.Element => {
         onDeleteTextInput,
         addInputField,
         onChangeDropdown,
-        onDismissSnackbar,
-        onUndoPressed,
         useCamera,
         isSubmiting,
     } = props;
@@ -232,31 +222,6 @@ const AddEdit = (props: Props): JSX.Element => {
         </View>
     );
 
-    const showSnackbar = (): JSX.Element =>
-        snackbar.isActionVisible ? (
-            <Snackbar
-                visible={snackbar.isVisible}
-                style={styles.snackbar}
-                onDismiss={onDismissSnackbar}
-                theme={{ colors: { accent: colors.textWhite } }}
-                action={{
-                    label: 'Undo',
-                    onPress: (): void => onUndoPressed(snackbar.label),
-                }}
-            >
-                {snackbar.message}
-            </Snackbar>
-        ) : (
-            <Snackbar
-                visible={snackbar.isVisible}
-                style={styles.snackbar}
-                onDismiss={onDismissSnackbar}
-                theme={{ colors: { accent: colors.textWhite } }}
-            >
-                {snackbar.message}
-            </Snackbar>
-        );
-
     return (
         <View style={styles.container}>
             <ScrollView>
@@ -305,7 +270,6 @@ const AddEdit = (props: Props): JSX.Element => {
                     <GroupButton onGroups={onGroups} groups={groups} id={contact.id} />
                 </View>
             </ScrollView>
-            {showSnackbar()}
         </View>
     );
 };

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
-import { TextInput, IconButton, Menu, Divider } from 'react-native-paper';
+import { TextInput, IconButton, Snackbar, Menu, Divider } from 'react-native-paper';
 import { icons, formLabels, modes, contactLabels } from '../StringsHelper';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { MaterialCommunityIcons } from 'react-native-vector-icons';
 import RNPickerSelect from 'react-native-picker-select';
-import { navigationT } from '../CustomTypes';
+import { navigationT, snackbarT } from '../CustomTypes';
 import GroupButton from './GroupButton';
 import { Group } from '../../redux/reducers/GroupsReducer';
 import ProperAvatar from '../ProperAvatar';
@@ -37,6 +37,11 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'flex-end',
     },
+    snackbar: {
+        position: 'absolute',
+        backgroundColor: colors.primaryDark,
+        bottom: 0,
+    },
     iconContainer: {
         width: 60,
         alignItems: 'center',
@@ -63,6 +68,7 @@ interface Props {
     pickImage: () => void;
     setImage: (string) => void;
     setIsMenuVisible: (boolean) => void;
+    snackbar: snackbarT;
     onGroups: (id: number | null) => void;
     onChangeName: (name: string) => void;
     onChangeSecondName: (secondName: string) => void;
@@ -72,6 +78,7 @@ interface Props {
     onDeleteTextInput: (label: string, index: number) => void;
     addInputField: (label: string) => void;
     onChangeDropdown: (label: string, test: string, index: number) => void;
+    onDismissSnackbar: () => void;
     onUndoPressed: (label: string) => void;
     useCamera: () => void;
     isSubmiting: boolean;
@@ -89,6 +96,7 @@ const AddEdit = (props: Props): JSX.Element => {
         isMenuVisible,
         pickImage,
         setIsMenuVisible,
+        snackbar,
         onGroups,
         onChangeName,
         onChangeSecondName,
@@ -98,6 +106,8 @@ const AddEdit = (props: Props): JSX.Element => {
         onDeleteTextInput,
         addInputField,
         onChangeDropdown,
+        onDismissSnackbar,
+        onUndoPressed,
         useCamera,
         isSubmiting,
     } = props;
@@ -222,6 +232,31 @@ const AddEdit = (props: Props): JSX.Element => {
         </View>
     );
 
+    const showSnackbar = (): JSX.Element =>
+        snackbar.isValidationMsg && snackbar.isActionVisible ? (
+            <Snackbar
+                visible={snackbar.isVisible}
+                style={styles.snackbar}
+                onDismiss={onDismissSnackbar}
+                theme={{ colors: { accent: colors.textWhite } }}
+                action={{
+                    label: 'Undo',
+                    onPress: (): void => onUndoPressed(snackbar.message.split(' ')[0]),
+                }}
+            >
+                {snackbar.message}
+            </Snackbar>
+        ) : (
+            <Snackbar
+                visible={snackbar.isVisible}
+                style={styles.snackbar}
+                onDismiss={onDismissSnackbar}
+                theme={{ colors: { accent: colors.textWhite } }}
+            >
+                {snackbar.message}
+            </Snackbar>
+        );
+
     return (
         <View style={styles.container}>
             <ScrollView>
@@ -270,6 +305,7 @@ const AddEdit = (props: Props): JSX.Element => {
                     <GroupButton onGroups={onGroups} groups={groups} id={contact.id} />
                 </View>
             </ScrollView>
+            {showSnackbar()}
         </View>
     );
 };

--- a/src/screens/AddEdit/AddEdit.tsx
+++ b/src/screens/AddEdit/AddEdit.tsx
@@ -81,6 +81,7 @@ interface Props {
     onDismissSnackbar: () => void;
     onUndoPressed: (label: string) => void;
     useCamera: () => void;
+    isSubmiting: boolean;
 }
 
 const AddEdit = (props: Props): JSX.Element => {
@@ -108,16 +109,23 @@ const AddEdit = (props: Props): JSX.Element => {
         onDismissSnackbar,
         onUndoPressed,
         useCamera,
+        isSubmiting,
     } = props;
 
     React.useLayoutEffect(() => {
         navigation.setOptions({
             title: mode === modes.edit ? 'Edit contact' : 'Create contact',
             headerRight: (): JSX.Element => (
-                <IconButton icon='check' size={40} color={'white'} onPress={(): void => onSaveContact()} />
+                <IconButton
+                    icon='check'
+                    size={40}
+                    color={'white'}
+                    onPress={(): void => onSaveContact()}
+                    disabled={isSubmiting}
+                />
             ),
         });
-    }, [navigation, onSaveContact, contact.id, mode]);
+    }, [navigation, onSaveContact, contact.id, mode, isSubmiting]);
 
     const showIconOrEmptySpace = (condition: boolean, icon: string): JSX.Element => (
         <View style={styles.iconContainer}>

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -12,7 +12,7 @@ import { Group } from '../../redux/reducers/GroupsReducer';
 import { createContact, removeTempGroups, updateContact } from '../../redux/actions/ActionCreators';
 import { Contact, ContactEmail, ContactNumber } from '../../redux/reducers/ContactsReducer';
 import addNewestContactToGroup from '../../redux/actions/addNewestContactToGroups';
-import { SnackbarContext } from '../ToastContent';
+import { SnackbarContext } from '../SnackbarContent';
 
 const showDeclinedPermissionAlert = (): void => {
     Alert.alert(
@@ -61,6 +61,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         category: defaultCathegory
     }]));
     const [deletedEmail, setDeletedEmail] = useState({ index: -1, delEmail: { email: '', category: '' } });
+    const [snackbar, setSnackbar] = useState({ isVisible: false, message: '', isActionVisible: false, isValidationMsg: true });
     const [isDeleteClicked, setIsDeleteClicked] = useState(false); //Logika pomagająca przy procesie usuwania/cofania usunięcia,
     const [dataValid, setDataValid] = useState({
         nameOrOneNumberEmpty: true,
@@ -102,7 +103,13 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         navigate('Groups', {id, mode});
     };
     const onMain = (): void => {
-        navigate('List');
+        setTimeout(() => {
+            if(isEdit) {
+                navigate('Details', { id, mode: modes.edit });
+            } else {
+                navigate('List');
+            }
+        }, 500)
     };
     const onChangeName = (value: string): void => {
         setFirstName(value);
@@ -113,8 +120,15 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const onChangeLastName = (value: string): void => {
         setSurname(value);
     };
-    const onShowSnackbar = (message: string, isActionVisible: boolean): void => {
-        show({message: message, isActionVisible: isActionVisible});
+    const onDismissSnackbar = (): void => {
+        setSnackbar({ isVisible: false, message: '', isActionVisible: false, isValidationMsg: true,});
+    };
+    const onShowSnackbar = (isVisible: boolean, message: string, isActionVisible: boolean, isValidationMsg: boolean): void => {
+        if(isActionVisible || isValidationMsg) {
+            setSnackbar({ isVisible: true, message: message, isActionVisible: isActionVisible,  isValidationMsg: isValidationMsg});
+        } else {
+            show({message: message});
+        }
     };
 
     const checkDataValidation = (): validationT => {
@@ -163,12 +177,13 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         } else if (label === formLabels.email) {
             setEmails([...emails, { email: '', category: defaultCathegory }]);
         } else {
-            onShowSnackbar( 'Something went wrong.', false);
+            onShowSnackbar(true, 'Something went wrong.', false, true);
             console.log('Błąd podczas dodawania nowego pola, nieznana etykieta.');
         }
     };
 
     const onChangeTextInput = (label: string, value: string, index: number): void => {
+        onDismissSnackbar();
         let tmpData;
         if (label === formLabels.number) {
             tmpData = [...numbers];
@@ -181,12 +196,13 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             setEmails(tmpData);
             setDeletedEmail({ index, delEmail: tmpData[index] });
         } else {
-            onShowSnackbar( 'Something went wrong.', false);
+            onShowSnackbar(true, 'Something went wrong.', false, true);
             console.log('Błąd pdczas zmiany danych w polu tekstowym, nieznana etykieta.');
         }
     };
 
     const onChangeDropdown = (label: string, value: string, index: number): void => {
+        onDismissSnackbar();
         if (!isDeleteClicked) {
             let tmpData;
             if (label === formLabels.number) {
@@ -200,7 +216,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
                 setEmails(tmpData);
                 setDeletedEmail({ index, delEmail: tmpData[index] });
             } else {
-                onShowSnackbar( 'Something went wrong.', false);
+                onShowSnackbar(true, 'Something went wrong.', false, true);
                 console.log('Błąd podczas zmiany danych w rozwijanym menu, nieznana etykieta.');
             }
         }
@@ -215,15 +231,15 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             tmpData = [...numbers];
             tmpData.splice(index, 1);
             setNumbers(tmpData);
-            onShowSnackbar( 'Number deleted.', true);
+            onShowSnackbar(true, 'Number deleted.', true, true);
         } else if (label === formLabels.email) {
             setDeletedEmail({ index, delEmail: emails[index] });
             tmpData = [...emails];
             tmpData.splice(index, 1);
             setEmails(tmpData);
-            onShowSnackbar( 'Email deleted.', true);
+            onShowSnackbar(true, 'Email deleted.', true, true);
         } else {
-            onShowSnackbar( 'Something went wrong.', false);
+            onShowSnackbar(true, 'Something went wrong.', false, true);
             console.log('Błąd podczas usuwania pola tekstowego, nieznana etykieta.');
         }
     };
@@ -240,19 +256,19 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             tmpData.splice(deletedEmail.index, 0, deletedEmail.delEmail);
             setEmails(tmpData);
         } else {
-            onShowSnackbar( 'Undo action failed. Something went wrong.', false);
+            onShowSnackbar(true, 'Undo action failed. Something went wrong.', false, true);
         }
     };
 
     const saveMessage = (dataValidOk: boolean): void => {
         if (dataValidOk) {
-            onShowSnackbar( 'Contact saved.', false );
+            onShowSnackbar(true, 'Contact saved.', false, false);
         } else if (dataValid.nameOrOneNumberEmpty) {
-            onShowSnackbar( 'Please enter your name and at least one phone number.', false);
+            onShowSnackbar(true, 'Please enter your name and at least one phone number.', false, true);
         } else if (dataValid.oneOfNumbersEmpty) {
-            onShowSnackbar( 'Fill out the fields with the phone number.', false);
+            onShowSnackbar(true, 'Fill out the fields with the phone number.', false, true);
         } else if (dataValid.oneOfEmailsEmpty) {
-            onShowSnackbar( 'Fill out the fields with the email adress.', false);
+            onShowSnackbar(true, 'Fill out the fields with the email adress.', false, true);
         }
     };
 
@@ -360,6 +376,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             pickImage={pickImage}
             setImage={setImage}
             setIsMenuVisible={setIsMenuVisible}
+            snackbar={snackbar}
             onGroups={onGroups}
             onChangeName={onChangeName}
             onChangeSecondName={onChangeSecondName}
@@ -369,6 +386,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             onDeleteTextInput={onDeleteTextInput}
             addInputField={addInputField}
             onChangeDropdown={onChangeDropdown}
+            onDismissSnackbar={onDismissSnackbar}
             onUndoPressed={onUndoPressed}
             useCamera={useCamera}
             isSubmiting={isSubmiting}

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable prettier/prettier */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useContext } from 'react';
 import AddEdit from './AddEdit';
 import { getContacts, getGroups, getTempGroupsIds } from '../../redux/selectors/Selectors';
 import { useNavigation } from '@react-navigation/native';
@@ -12,6 +12,7 @@ import { Group } from '../../redux/reducers/GroupsReducer';
 import { createContact, removeTempGroups, updateContact } from '../../redux/actions/ActionCreators';
 import { Contact, ContactEmail, ContactNumber } from '../../redux/reducers/ContactsReducer';
 import addNewestContactToGroup from '../../redux/actions/addNewestContactToGroups';
+import { SnackbarContext } from '../ToastContent';
 
 const showDeclinedPermissionAlert = (): void => {
     Alert.alert(
@@ -28,6 +29,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     //wartości początkowe
     const { navigate } = useNavigation();
     const { id, mode } = route.params;
+    const { show } = useContext(SnackbarContext);
     const contacts = useSelector(getContacts);
     const groups = useSelector(getGroups);
     const tempGroupsIds = useSelector(getTempGroupsIds);
@@ -59,7 +61,6 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         category: defaultCathegory
     }]));
     const [deletedEmail, setDeletedEmail] = useState({ index: -1, delEmail: { email: '', category: '' } });
-    const [snackbar, setSnackbar] = useState({ isVisible: false, message: '', isActionVisible: false, label: '' });
     const [isDeleteClicked, setIsDeleteClicked] = useState(false); //Logika pomagająca przy procesie usuwania/cofania usunięcia,
     const [dataValid, setDataValid] = useState({
         nameOrOneNumberEmpty: true,
@@ -112,11 +113,8 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     const onChangeLastName = (value: string): void => {
         setSurname(value);
     };
-    const onDismissSnackbar = (): void => {
-        setSnackbar({ isVisible: false, message: '', isActionVisible: false, label: '' });
-    };
-    const onShowSnackbar = (isVisible: true, message: string, isActionVisible: boolean, label: string): void => {
-        setSnackbar({ isVisible: true, message: message, isActionVisible: isActionVisible, label: label });
+    const onShowSnackbar = (message: string, isActionVisible: boolean): void => {
+        show({message: message, isActionVisible: isActionVisible});
     };
 
     const checkDataValidation = (): validationT => {
@@ -165,13 +163,12 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         } else if (label === formLabels.email) {
             setEmails([...emails, { email: '', category: defaultCathegory }]);
         } else {
-            onShowSnackbar(true, 'Something went wrong.', false, '');
+            onShowSnackbar( 'Something went wrong.', false);
             console.log('Błąd podczas dodawania nowego pola, nieznana etykieta.');
         }
     };
 
     const onChangeTextInput = (label: string, value: string, index: number): void => {
-        onDismissSnackbar();
         let tmpData;
         if (label === formLabels.number) {
             tmpData = [...numbers];
@@ -184,14 +181,13 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             setEmails(tmpData);
             setDeletedEmail({ index, delEmail: tmpData[index] });
         } else {
-            onShowSnackbar(true, 'Something went wrong.', false, '');
+            onShowSnackbar( 'Something went wrong.', false);
             console.log('Błąd pdczas zmiany danych w polu tekstowym, nieznana etykieta.');
         }
     };
 
     const onChangeDropdown = (label: string, value: string, index: number): void => {
         if (!isDeleteClicked) {
-            onDismissSnackbar();
             let tmpData;
             if (label === formLabels.number) {
                 tmpData = [...numbers];
@@ -204,7 +200,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
                 setEmails(tmpData);
                 setDeletedEmail({ index, delEmail: tmpData[index] });
             } else {
-                onShowSnackbar(true, 'Something went wrong.', false, '');
+                onShowSnackbar( 'Something went wrong.', false);
                 console.log('Błąd podczas zmiany danych w rozwijanym menu, nieznana etykieta.');
             }
         }
@@ -219,15 +215,15 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             tmpData = [...numbers];
             tmpData.splice(index, 1);
             setNumbers(tmpData);
-            onShowSnackbar(true, 'Number deleted.', true, label);
+            onShowSnackbar( 'Number deleted.', true);
         } else if (label === formLabels.email) {
             setDeletedEmail({ index, delEmail: emails[index] });
             tmpData = [...emails];
             tmpData.splice(index, 1);
             setEmails(tmpData);
-            onShowSnackbar(true, 'Email deleted.', true, label);
+            onShowSnackbar( 'Email deleted.', true);
         } else {
-            onShowSnackbar(true, 'Something went wrong.', false, '');
+            onShowSnackbar( 'Something went wrong.', false);
             console.log('Błąd podczas usuwania pola tekstowego, nieznana etykieta.');
         }
     };
@@ -244,19 +240,19 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             tmpData.splice(deletedEmail.index, 0, deletedEmail.delEmail);
             setEmails(tmpData);
         } else {
-            onShowSnackbar(true, 'Undo action failed. Something went wrong.', false, '');
+            onShowSnackbar( 'Undo action failed. Something went wrong.', false);
         }
     };
 
     const saveMessage = (dataValidOk: boolean): void => {
         if (dataValidOk) {
-            onShowSnackbar(true, 'Contact saved.', false, '');
+            onShowSnackbar( 'Contact saved.', false );
         } else if (dataValid.nameOrOneNumberEmpty) {
-            onShowSnackbar(true, 'Please enter your name and at least one phone number.', false, '');
+            onShowSnackbar( 'Please enter your name and at least one phone number.', false);
         } else if (dataValid.oneOfNumbersEmpty) {
-            onShowSnackbar(true, 'Fill out the fields with the phone number.', false, '');
+            onShowSnackbar( 'Fill out the fields with the phone number.', false);
         } else if (dataValid.oneOfEmailsEmpty) {
-            onShowSnackbar(true, 'Fill out the fields with the email adress.', false, '');
+            onShowSnackbar( 'Fill out the fields with the email adress.', false);
         }
     };
 
@@ -272,9 +268,9 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
                 } else if (mode === modes.edit && id !== null) {
                     dispatch(updateContact(buildContactObject(), id));
                 }
+                onMain();
             }
             saveMessage(dataValidOk);
-            onMain();
         } catch (e) {
             console.log(e);
         }
@@ -364,7 +360,6 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             pickImage={pickImage}
             setImage={setImage}
             setIsMenuVisible={setIsMenuVisible}
-            snackbar={snackbar}
             onGroups={onGroups}
             onChangeName={onChangeName}
             onChangeSecondName={onChangeSecondName}
@@ -374,7 +369,6 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             onDeleteTextInput={onDeleteTextInput}
             addInputField={addInputField}
             onChangeDropdown={onChangeDropdown}
-            onDismissSnackbar={onDismissSnackbar}
             onUndoPressed={onUndoPressed}
             useCamera={useCamera}
             isSubmiting={isSubmiting}

--- a/src/screens/AddEdit/index.tsx
+++ b/src/screens/AddEdit/index.tsx
@@ -66,6 +66,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         oneOfNumbersEmpty: true,
         oneOfEmailsEmpty: true
     });
+    const [isSubmiting, setIsSubmiting] = useState(false);
 
 
     const filterGroupsForContact = (): Group[] => {
@@ -98,6 +99,9 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
     }
     const onGroups = (): void => {
         navigate('Groups', {id, mode});
+    };
+    const onMain = (): void => {
+        navigate('List');
     };
     const onChangeName = (value: string): void => {
         setFirstName(value);
@@ -261,6 +265,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
         try{
             const dataValidOk = !dataValid.nameOrOneNumberEmpty && !dataValid.oneOfNumbersEmpty && !dataValid.oneOfEmailsEmpty;
             if (dataValidOk) {
+                setIsSubmiting(true);
                 if (mode === modes.create) {
                     dispatch(createContact(buildContactObject()));
                     dispatch(addNewestContactToGroup(tempGroupsIds));
@@ -269,6 +274,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
                 }
             }
             saveMessage(dataValidOk);
+            onMain();
         } catch (e) {
             console.log(e);
         }
@@ -371,6 +377,7 @@ const AddEditScreen = ({ route, navigation }): JSX.Element => {
             onDismissSnackbar={onDismissSnackbar}
             onUndoPressed={onUndoPressed}
             useCamera={useCamera}
+            isSubmiting={isSubmiting}
         />
     );
 };

--- a/src/screens/CustomTypes.ts
+++ b/src/screens/CustomTypes.ts
@@ -1,10 +1,3 @@
-export type snackbarT = {
-    isVisible: boolean;
-    message: string;
-    isActionVisible: boolean;
-    label: string;
-};
-
 export type navigationT = {
     setOptions(param: { headerRight: () => JSX.Element; title: string }): void;
 };

--- a/src/screens/CustomTypes.ts
+++ b/src/screens/CustomTypes.ts
@@ -1,3 +1,10 @@
+export type snackbarT = {
+    isVisible: boolean;
+    message: string;
+    isActionVisible: boolean;
+    isValidationMsg: boolean,
+};
+
 export type navigationT = {
     setOptions(param: { headerRight: () => JSX.Element; title: string }): void;
 };

--- a/src/screens/SnackbarContent.tsx
+++ b/src/screens/SnackbarContent.tsx
@@ -2,35 +2,31 @@ import React, { createContext, useState, useEffect, useRef, useCallback } from '
 
 export interface ToastT {
     message: string;
-    type: string | null;
     visible: boolean;
-    isActionVisible: boolean;
 }
 
 const initialToast: ToastT = {
     message: '',
-    type: null,
     visible: false,
-    isActionVisible: false,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any,@typescript-eslint/no-empty-function
-export const SnackbarContext = createContext({ hide: () => {}, show: (args: any) => {}, toast: initialToast});
+export const SnackbarContext = createContext({ hide: () => {}, show: (args: any) => {}, snackbar: initialToast });
 
 export const SnackbarProvider = ({ children }) => {
-    const [toast, setToast] = useState(initialToast);
+    const [snackbar, setSnackbar] = useState(initialToast);
     const timeout = useRef<number>();
 
     const show = useCallback((args) => {
-        setToast({ ...initialToast, visible: true, ...args });
+        setSnackbar({ ...initialToast, visible: true, ...args });
     }, []);
 
     const hide = useCallback(() => {
-        setToast({ ...toast, visible: false });
-    }, [toast]);
+        setSnackbar({ ...snackbar, visible: false });
+    }, [snackbar]);
 
     useEffect(() => {
-        if (toast.visible) {
+        if (snackbar.visible) {
             timeout.current = setTimeout(hide, 2500);
             return () => {
                 if (timeout.current) {
@@ -38,14 +34,14 @@ export const SnackbarProvider = ({ children }) => {
                 }
             };
         }
-    }, [hide, toast]);
+    }, [hide, snackbar]);
 
     return (
         <SnackbarContext.Provider
             value={{
                 hide,
                 show,
-                toast,
+                snackbar,
             }}
         >
             {children}

--- a/src/screens/SnackbarCustom.tsx
+++ b/src/screens/SnackbarCustom.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { SnackbarContext } from './ToastContent';
+import { SnackbarContext } from './SnackbarContent';
 import { StyleSheet } from 'react-native';
 import { Snackbar } from 'react-native-paper';
 import { colors } from '../styles/common';
@@ -15,20 +15,7 @@ const styles = StyleSheet.create({
 export const SnackbarCustom = (): JSX.Element => {
     const { toast, hide } = useContext(SnackbarContext);
 
-    return toast.isActionVisible ? (
-        <Snackbar
-            visible={toast.visible}
-            style={styles.snackbar}
-            onDismiss={(): void => hide()}
-            theme={{ colors: { accent: colors.textWhite } }}
-            action={{
-                label: 'Undo',
-                onPress: (): void => console.log('UNDO'),
-            }}
-        >
-            {toast.message}
-        </Snackbar>
-    ) : (
+    return (
         <Snackbar
             visible={toast.visible}
             style={styles.snackbar}

--- a/src/screens/SnackbarCustom.tsx
+++ b/src/screens/SnackbarCustom.tsx
@@ -13,16 +13,16 @@ const styles = StyleSheet.create({
 });
 
 export const SnackbarCustom = (): JSX.Element => {
-    const { toast, hide } = useContext(SnackbarContext);
+    const { snackbar, hide } = useContext(SnackbarContext);
 
     return (
         <Snackbar
-            visible={toast.visible}
+            visible={snackbar.visible}
             style={styles.snackbar}
             onDismiss={(): void => hide()}
             theme={{ colors: { accent: colors.textWhite } }}
         >
-            {toast.message}
+            {snackbar.message}
         </Snackbar>
     );
 };

--- a/src/screens/SnackbarCustom.tsx
+++ b/src/screens/SnackbarCustom.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import { SnackbarContext } from './ToastContent';
+import { StyleSheet } from 'react-native';
+import { Snackbar } from 'react-native-paper';
+import { colors } from '../styles/common';
+
+const styles = StyleSheet.create({
+    snackbar: {
+        position: 'absolute',
+        backgroundColor: colors.primaryDark,
+        bottom: 0,
+    },
+});
+
+export const SnackbarCustom = (): JSX.Element => {
+    const { toast, hide } = useContext(SnackbarContext);
+
+    return toast.isActionVisible ? (
+        <Snackbar
+            visible={toast.visible}
+            style={styles.snackbar}
+            onDismiss={(): void => hide()}
+            theme={{ colors: { accent: colors.textWhite } }}
+            action={{
+                label: 'Undo',
+                onPress: (): void => console.log('UNDO'),
+            }}
+        >
+            {toast.message}
+        </Snackbar>
+    ) : (
+        <Snackbar
+            visible={toast.visible}
+            style={styles.snackbar}
+            onDismiss={(): void => hide()}
+            theme={{ colors: { accent: colors.textWhite } }}
+        >
+            {toast.message}
+        </Snackbar>
+    );
+};
+
+export default SnackbarCustom;

--- a/src/screens/ToastContent.tsx
+++ b/src/screens/ToastContent.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useState, useEffect, useRef, useCallback } from 'react';
+
+export interface ToastT {
+    message: string;
+    type: string | null;
+    visible: boolean;
+    isActionVisible: boolean;
+}
+
+const initialToast: ToastT = {
+    message: '',
+    type: null,
+    visible: false,
+    isActionVisible: false,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any,@typescript-eslint/no-empty-function
+export const SnackbarContext = createContext({ hide: () => {}, show: (args: any) => {}, toast: initialToast});
+
+export const SnackbarProvider = ({ children }) => {
+    const [toast, setToast] = useState(initialToast);
+    const timeout = useRef<number>();
+
+    const show = useCallback((args) => {
+        setToast({ ...initialToast, visible: true, ...args });
+    }, []);
+
+    const hide = useCallback(() => {
+        setToast({ ...toast, visible: false });
+    }, [toast]);
+
+    useEffect(() => {
+        if (toast.visible) {
+            timeout.current = setTimeout(hide, 2500);
+            return () => {
+                if (timeout.current) {
+                    clearTimeout(timeout.current);
+                }
+            };
+        }
+    }, [hide, toast]);
+
+    return (
+        <SnackbarContext.Provider
+            value={{
+                hide,
+                show,
+                toast,
+            }}
+        >
+            {children}
+        </SnackbarContext.Provider>
+    );
+};


### PR DESCRIPTION
Zmiany:
- Po zapisie po 0.5 sekundy nawiguje do ekranu listy kontaktów lub edycji
- Snackbary: zrobiłem snackbar 'globalny' widoczny wszędzie (powiadomienia typu zapisano, usunięto) i snackbary dotyczące walidacji (żeby np. komunikat 'Please enter your name and at least one phone number.' nie był widoczny po cofnięciu się strzałką na poprzedni ekran)

@bartlomiej-szlachta  @oliwiabrozek po tym jak wejdzie ten pull request dodajcie snackbar z informacją o usunięciu kontaktu do swoich zmian